### PR TITLE
Fix circup install command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ following command to install:
 
 .. code-block:: shell
 
-    circup install nau7802
+    circup install cedargrove_nau7802
 
 Or the following command to update an existing version:
 


### PR DESCRIPTION
The package seems to be called `cedargrove_nau7802`, not just `nau7802`:

```
WARNING:
	nau7802 is not a known CircuitPython library.
```